### PR TITLE
feat: Add Straico and Azure OpenAI (Custom) providers

### DIFF
--- a/src/components/AddApiKeyForm.tsx
+++ b/src/components/AddApiKeyForm.tsx
@@ -1,5 +1,6 @@
 
 import { useForm } from "react-hook-form";
+import { useEffect } from "react"; // Added for watching provider, though direct watch is often enough
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -34,8 +35,20 @@ const AddApiKeyForm = ({ saveMutation }: AddApiKeyFormProps) => {
     defaultValues: {
       api_key: "",
       provider: undefined,
+      endpoint_url: "",
+      deployment_id: "",
     },
   });
+
+  const watchedProvider = form.watch('provider');
+
+  // Optional: Reset dependent fields when provider changes
+  useEffect(() => {
+    if (watchedProvider !== 'Azure OpenAI (Custom)') {
+      form.setValue('endpoint_url', undefined);
+      form.setValue('deployment_id', undefined);
+    }
+  }, [watchedProvider, form]);
 
   const onSubmit = (data: ApiKeyFormValues) => {
     saveMutation.mutate(data, {
@@ -94,6 +107,47 @@ const AddApiKeyForm = ({ saveMutation }: AddApiKeyFormProps) => {
             </FormItem>
           )}
         />
+
+        {watchedProvider === 'Azure OpenAI (Custom)' && (
+          <>
+            <FormField
+              control={form.control}
+              name="endpoint_url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Endpoint URL</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="url"
+                      placeholder="e.g., https://your-resource.openai.azure.com/"
+                      {...field}
+                      value={field.value || ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="deployment_id"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Deployment ID</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="text"
+                      placeholder="e.g., gpt-4o-mini"
+                      {...field}
+                      value={field.value || ""}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </>
+        )}
         <Button type="submit" className="w-full" disabled={saveMutation.isPending}>
           {saveMutation.isPending && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
           Save API Key

--- a/src/hooks/useApiKeys.ts
+++ b/src/hooks/useApiKeys.ts
@@ -11,6 +11,16 @@ export const apiKeySchema = z.object({
     required_error: "You need to select a provider.",
   }),
   api_key: z.string().min(1, "API key cannot be empty."),
+  endpoint_url: z.string().url({ message: "Must be a valid URL." }).optional(),
+  deployment_id: z.string().min(1, "Deployment ID cannot be empty.").optional(),
+})
+.refine(data => !(data.provider === 'Azure OpenAI (Custom)' && !data.endpoint_url), {
+  message: 'Endpoint URL is required for Azure OpenAI (Custom)',
+  path: ['endpoint_url'],
+})
+.refine(data => !(data.provider === 'Azure OpenAI (Custom)' && !data.deployment_id), {
+  message: 'Deployment ID is required for Azure OpenAI (Custom)',
+  path: ['deployment_id'],
 });
 
 export type ApiKeyFormValues = z.infer<typeof apiKeySchema>;
@@ -71,6 +81,8 @@ export const useApiKeys = () => {
         user_id: user.id,
         provider: values.provider,
         api_key: values.api_key,
+        endpoint_url: values.endpoint_url, // Add this
+        deployment_id: values.deployment_id, // Add this
       }, { onConflict: 'user_id, provider' });
       if (error) throw error;
     },

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -252,6 +252,8 @@ export type Database = {
         | "Google Gemini"
         | "Mistral"
         | "OpenRouter"
+        | "Straico"
+        | "Azure OpenAI (Custom)"
       message_role: "user" | "assistant"
     }
     CompositeTypes: {
@@ -374,6 +376,8 @@ export const Constants = {
         "Google Gemini",
         "Mistral",
         "OpenRouter",
+        "Straico",
+        "Azure OpenAI (Custom)",
       ],
       message_role: ["user", "assistant"],
     },

--- a/src/services/aiProviderService.ts
+++ b/src/services/aiProviderService.ts
@@ -118,7 +118,9 @@ export const getDefaultModel = (provider: string): string => {
     'Anthropic': 'claude-3-5-haiku-20241022',
     'Google Gemini': 'gemini-1.5-flash',
     'Mistral': 'mistral-small-latest',
-    'OpenRouter': 'anthropic/claude-3.5-sonnet'
+    'OpenRouter': 'anthropic/claude-3.5-sonnet',
+    'Straico': 'straico/latest',
+    'Azure OpenAI (Custom)': 'user-defined'
   };
 
   return defaultModels[provider] || 'gpt-4o-mini';
@@ -152,7 +154,9 @@ export const getAvailableModels = (provider:string): string[] => {
       'mistralai/mistral-large-latest',
       'meta-llama/llama-3-70b-instruct',
       'meta-llama/llama-3-8b-instruct',
-    ]
+    ],
+    'Straico': ['straico/latest'],
+    'Azure OpenAI (Custom)': ['user-defined']
   };
 
   return models[provider] || ['gpt-4o-mini'];

--- a/supabase/functions/ai-chat/auth/apiKeyHandler.ts
+++ b/supabase/functions/ai-chat/auth/apiKeyHandler.ts
@@ -1,7 +1,13 @@
 
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.7.1';
 
-async function getApiKeyForUser(authHeader: string, provider: string): Promise<string> {
+export interface ApiKeyDetails {
+  apiKey: string;
+  endpointUrl?: string;
+  deploymentId?: string;
+}
+
+async function getApiKeyForUser(authHeader: string, provider: string): Promise<ApiKeyDetails> {
     console.log('[ai-chat] Getting API key for authenticated user');
     
     const serviceClient = createClient(
@@ -29,7 +35,7 @@ async function getApiKeyForUser(authHeader: string, provider: string): Promise<s
 
     const { data: apiKeyData, error: apiKeyError } = await serviceClient
       .from('api_keys')
-      .select('api_key')
+      .select('api_key, endpoint_url, deployment_id')
       .eq('provider', provider)
       .eq('user_id', user.id)
       .maybeSingle();
@@ -44,28 +50,32 @@ async function getApiKeyForUser(authHeader: string, provider: string): Promise<s
       throw new Error(`No API key found for ${provider}. Please add your API key for this provider in the Settings page.`);
     }
 
-    console.log('[ai-chat] Successfully retrieved API key for authenticated user');
-    return apiKeyData.api_key;
+    console.log('[ai-chat] Successfully retrieved API key details for authenticated user');
+    return {
+      apiKey: apiKeyData.api_key,
+      endpointUrl: apiKeyData.endpoint_url,
+      deploymentId: apiKeyData.deployment_id,
+    };
 }
 
-export async function getApiKey(req: Request, guestApiKey: string | undefined, provider: string): Promise<string> {
-  let apiKey: string | undefined;
+export async function getApiKey(req: Request, guestApiKey: string | undefined, provider: string): Promise<ApiKeyDetails> {
+  let apiKeyDetails: ApiKeyDetails | undefined;
   const authHeader = req.headers.get('Authorization');
   
   if (guestApiKey) {
-    apiKey = guestApiKey;
+    apiKeyDetails = { apiKey: guestApiKey };
     console.log(`[ai-chat] Using guest API key for provider: ${provider}`);
   } else if (authHeader) {
-    apiKey = await getApiKeyForUser(authHeader, provider);
+    apiKeyDetails = await getApiKeyForUser(authHeader, provider);
   } else {
     console.error('[ai-chat] No authentication found (no user session or API key)');
     throw new Error('You must be logged in or provide an API key to chat.');
   }
 
-  if (!apiKey) {
+  if (!apiKeyDetails || !apiKeyDetails.apiKey) {
     console.error('[ai-chat] No API key available after all checks');
     throw new Error('Could not retrieve API key for the selected provider.');
   }
   
-  return apiKey;
+  return apiKeyDetails;
 }

--- a/supabase/functions/ai-chat/index.ts
+++ b/supabase/functions/ai-chat/index.ts
@@ -2,9 +2,9 @@
 import "https://deno.land/x/xhr@0.1.0/mod.ts";
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import { corsHeaders } from './_shared/cors.ts';
-import type { ChatRequest, NormalizedResponse } from './_shared/types.ts';
+import type { ChatRequest, NormalizedResponse, ProviderHandlerParams } from './_shared/types.ts';
 import { createOpenAINormalizer } from './streaming/openaiNormalizer.ts';
-import { getApiKey } from './auth/apiKeyHandler.ts';
+import { getApiKey, type ApiKeyDetails } from './auth/apiKeyHandler.ts';
 import { providerHandlers, defaultModels } from './providers/_registry.ts';
 
 serve(async (req) => {
@@ -25,9 +25,14 @@ serve(async (req) => {
 
     console.log(`[ai-chat] Provider: ${provider} | Model: ${model} | Guest?: ${!!guestApiKey} | Stream?: ${stream}`);
 
-    const apiKey = await getApiKey(req, guestApiKey, provider);
+    const apiKeyDetails: ApiKeyDetails = await getApiKey(req, guestApiKey, provider);
     const resolvedModel = model || defaultModels[provider];
     const handler = providerHandlers[provider];
+
+    const providerParams: ProviderHandlerParams = {
+      endpoint_url: apiKeyDetails.endpointUrl,
+      deployment_id: apiKeyDetails.deploymentId,
+    };
 
     if (!handler) {
       console.error(`[ai-chat] Unsupported provider: ${provider}`);
@@ -36,14 +41,37 @@ serve(async (req) => {
 
     // Handle streaming
     if (stream) {
-      if (provider === 'OpenAI') { // Currently only OpenAI supports streaming
-        const streamResponse = await handler(apiKey, resolvedModel, messages, temperature, max_tokens, true) as ReadableStream;
+      // TODO: Streaming for Azure OpenAI (Custom) would need its own normalizer if different from OpenAI
+      if (provider === 'OpenAI' || provider === 'Azure OpenAI (Custom)') {
+        const streamResponse = await handler(
+          apiKeyDetails.apiKey,
+          resolvedModel,
+          messages,
+          temperature,
+          max_tokens,
+          true,
+          providerParams
+        ) as ReadableStream;
+
+        // Assuming Azure OpenAI (Custom) stream is compatible with OpenAI normalizer for now
         const normalizedStream = streamResponse.pipeThrough(createOpenAINormalizer());
+
         return new Response(normalizedStream, {
           headers: { ...corsHeaders, 'Content-Type': 'text/plain; charset=utf-8' },
         });
       } else {
-        return new Response(JSON.stringify({ error: `Streaming is not supported for ${provider} yet.` }), {
+        // For other providers that might not support streaming or providerParams yet
+        if (providerHandlers[provider].length < 7 && (providerParams.endpoint_url || providerParams.deployment_id)) {
+           console.warn(`[ai-chat] Provider ${provider} does not support custom params but they were provided.`);
+        }
+        const streamResponse = await handler(apiKeyDetails.apiKey, resolvedModel, messages, temperature, max_tokens, true) as ReadableStream;
+        // Potentially use a generic normalizer or handle based on provider if normalizers differ
+        const normalizedStream = streamResponse.pipeThrough(createOpenAINormalizer());
+         return new Response(normalizedStream, {
+          headers: { ...corsHeaders, 'Content-Type': 'text/plain; charset=utf-8' },
+        });
+      }
+       return new Response(JSON.stringify({ error: `Streaming is not supported for ${provider} yet (or misconfigured).` }), {
           status: 400,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         });
@@ -52,17 +80,32 @@ serve(async (req) => {
 
     // Handle non-streaming requests
     try {
-      const response = await handler(apiKey, resolvedModel, messages, temperature, max_tokens, false) as NormalizedResponse;
+      const response = await handler(
+        apiKeyDetails.apiKey,
+        resolvedModel,
+        messages,
+        temperature,
+        max_tokens,
+        false,
+        providerParams
+      ) as NormalizedResponse;
       return new Response(JSON.stringify(response), {
         headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     } catch (providerError) {
       console.error(`[ai-chat] Error calling AI provider ${provider}:`, providerError);
+      const message = providerError instanceof Error ? providerError.message : String(providerError);
+      // Check if the error message indicates missing params for Azure
+      if (provider === 'Azure OpenAI (Custom)' && message.includes('endpoint URL or deployment ID is not configured')) {
+         return new Response(JSON.stringify({ error: `Configuration error for Azure OpenAI (Custom): ${message}. Please check your API key settings.` }), {
+          status: 400, // Bad Request, as it's a configuration issue on the user's side
+          headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+        });
+      }
       throw new Error(
-        `Failed to get response from ${provider}: ${providerError instanceof Error ? providerError.message : String(providerError)}`
+        `Failed to get response from ${provider}: ${message}`
       );
     }
-
   } catch (error) {
     const errMsg = (error && typeof error === "object" && "message" in error) ? (error as Error).message : String(error);
     console.error('[ai-chat] Error:', errMsg);

--- a/supabase/functions/ai-chat/providers/_registry.ts
+++ b/supabase/functions/ai-chat/providers/_registry.ts
@@ -4,6 +4,8 @@ import { handleAnthropic } from './anthropic.ts';
 import { handleGemini } from './gemini.ts';
 import { handleMistral } from './mistral.ts';
 import { handleOpenRouter } from './openrouter.ts';
+import { handleStraico } from './straico.ts';
+import { handleCustomAzureOpenAI } from './customAzureOpenAI.ts';
 import type { ChatMessage, NormalizedResponse } from '../_shared/types.ts';
 
 type ProviderHandler = (
@@ -12,7 +14,9 @@ type ProviderHandler = (
   messages: ChatMessage[],
   temperature: number,
   max_tokens: number,
-  stream?: boolean
+  stream?: boolean,
+  // Adding providerParams to the type to match handleCustomAzureOpenAI and future needs
+  providerParams?: Record<string, string | undefined>
 ) => Promise<NormalizedResponse | ReadableStream>;
 
 export const providerHandlers: Record<string, ProviderHandler> = {
@@ -21,6 +25,8 @@ export const providerHandlers: Record<string, ProviderHandler> = {
   'Google Gemini': handleGemini as ProviderHandler,
   'Mistral': handleMistral as ProviderHandler,
   'OpenRouter': handleOpenRouter as ProviderHandler,
+  'Straico': handleStraico as ProviderHandler,
+  'Azure OpenAI (Custom)': handleCustomAzureOpenAI as ProviderHandler,
 };
 
 export const defaultModels: Record<string, string> = {
@@ -29,4 +35,6 @@ export const defaultModels: Record<string, string> = {
   'Google Gemini': 'gemini-1.5-flash',
   'Mistral': 'mistral-small-latest',
   'OpenRouter': 'anthropic/claude-3.5-sonnet',
+  'Straico': 'straico/latest',
+  'Azure OpenAI (Custom)': 'user-defined',
 };

--- a/supabase/functions/ai-chat/providers/customAzureOpenAI.test.ts
+++ b/supabase/functions/ai-chat/providers/customAzureOpenAI.test.ts
@@ -1,0 +1,201 @@
+import { assertEquals, assertRejects, assertInstanceOf, assertStringIncludes } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { handleCustomAzureOpenAI } from "./customAzureOpenAI.ts";
+import type { ChatMessage, NormalizedResponse, ProviderHandlerParams } from '../_shared/types.ts';
+
+const DEFAULT_API_VERSION = '2025-01-01-preview'; // Match the one in customAzureOpenAI.ts
+
+// Store original fetch to restore it after tests
+const originalFetch = globalThis.fetch;
+
+const commonMessages: ChatMessage[] = [{ role: "user", content: "Hello Azure" }];
+const commonApiKey = "test-azure-key";
+const commonModel = "gpt-4o-deployment"; // This is the deployment_id
+
+Deno.test("handleCustomAzureOpenAI - successful non-streaming response (endpoint without slash)", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com", deployment_id: commonModel };
+  const expectedUrl = `https://test-resource.openai.azure.com/openai/deployments/${commonModel}/chat/completions?api-version=${DEFAULT_API_VERSION}`;
+
+  globalThis.fetch = async (url: string | URL | Request, options?: RequestInit): Promise<Response> => {
+    assertEquals(url.toString(), expectedUrl);
+    assertEquals(options?.method, "POST");
+    if (options?.headers) {
+      const headers = new Headers(options.headers);
+      assertEquals(headers.get("api-key"), commonApiKey);
+      assertEquals(headers.get("Content-Type"), "application/json");
+    }
+    if (options?.body) {
+      const body = JSON.parse(options.body as string);
+      assertEquals(body.stream, false);
+    }
+    return Promise.resolve(new Response(JSON.stringify({
+      choices: [{ message: { content: "Azure says hello" } }],
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      model: commonModel // Azure might return the deployment ID or a base model name
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  };
+
+  try {
+    const response = await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params) as NormalizedResponse;
+    assertEquals(response.content, "Azure says hello");
+    assertEquals(response.provider, "Azure OpenAI (Custom)");
+    assertEquals(response.model, commonModel);
+    assertEquals(response.usage?.total_tokens, 30);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleCustomAzureOpenAI - successful non-streaming response (endpoint with slash)", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com/", deployment_id: commonModel };
+  const expectedUrl = `https://test-resource.openai.azure.com/openai/deployments/${commonModel}/chat/completions?api-version=${DEFAULT_API_VERSION}`;
+
+  globalThis.fetch = async (url: string | URL | Request, _options?: RequestInit): Promise<Response> => {
+    assertEquals(url.toString(), expectedUrl); // Main check for this test
+    return Promise.resolve(new Response(JSON.stringify({
+      choices: [{ message: { content: "Azure response" } }],
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  };
+
+  try {
+    await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params);
+    // Basic check passed if fetch was called with correct URL
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+
+Deno.test("handleCustomAzureOpenAI - API error handling (401 Unauthorized)", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com", deployment_id: commonModel };
+  globalThis.fetch = async (_url, _options): Promise<Response> => {
+    return Promise.resolve(new Response(JSON.stringify({ error: { message: "Invalid API key" } }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    }));
+  };
+
+  try {
+    await assertRejects(
+      async () => {
+        await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params);
+      },
+      Error,
+      'Custom Azure OpenAI API error: 401 {"error":{"message":"Invalid API key"}}'
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleCustomAzureOpenAI - missing endpoint_url configuration", async () => {
+  const params: ProviderHandlerParams = { deployment_id: commonModel }; // endpoint_url is missing
+  await assertRejects(
+    async () => {
+      await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params);
+    },
+    Error,
+    "Azure OpenAI endpoint URL or deployment ID is not configured for this API key."
+  );
+});
+
+Deno.test("handleCustomAzureOpenAI - missing deployment_id configuration", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com" }; // deployment_id is missing
+  await assertRejects(
+    async () => {
+      await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params);
+    },
+    Error,
+    "Azure OpenAI endpoint URL or deployment ID is not configured for this API key."
+  );
+});
+
+Deno.test("handleCustomAzureOpenAI - successful streaming response", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com", deployment_id: commonModel };
+  const mockStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("data: chunk1\n\n"));
+      controller.close();
+    }
+  });
+
+  globalThis.fetch = async (url: string | URL | Request, options?: RequestInit): Promise<Response> => {
+    const body = JSON.parse(options!.body as string);
+    assertEquals(body.stream, true);
+    return Promise.resolve(new Response(mockStream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' }
+    }));
+  };
+
+  try {
+    const response = await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, true, params);
+    assertInstanceOf(response, ReadableStream);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleCustomAzureOpenAI - non-JSON error response from API", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com", deployment_id: commonModel };
+  globalThis.fetch = async (_url, _options): Promise<Response> => {
+    return Promise.resolve(new Response("Internal Server Error - Plain Text", {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain' }
+    }));
+  };
+
+  try {
+    await assertRejects(
+      async () => {
+        await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params);
+      },
+      Error,
+      "Custom Azure OpenAI API error: 500 Internal Server Error - Plain Text"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleCustomAzureOpenAI - stream response with null body", async () => {
+ const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com", deployment_id: commonModel };
+  globalThis.fetch = async (_url, _options): Promise<Response> => {
+    return Promise.resolve(new Response(null, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' }
+    }));
+  };
+
+  try {
+    await assertRejects(
+      async () => {
+        await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, true, params);
+      },
+      Error,
+      "Custom Azure OpenAI API response body is null for stream."
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleCustomAzureOpenAI - non-streaming unexpected response structure", async () => {
+  const params: ProviderHandlerParams = { endpoint_url: "https://test-resource.openai.azure.com", deployment_id: commonModel };
+  globalThis.fetch = async (_url, _options): Promise<Response> => {
+    return Promise.resolve(new Response(JSON.stringify({
+      invalid_structure: "no choices field"
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  };
+
+  try {
+    await assertRejects(
+      async () => {
+        await handleCustomAzureOpenAI(commonApiKey, commonModel, commonMessages, 0.7, 100, false, params);
+      },
+      Error,
+      "Unexpected Custom Azure OpenAI API response structure"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/supabase/functions/ai-chat/providers/customAzureOpenAI.ts
+++ b/supabase/functions/ai-chat/providers/customAzureOpenAI.ts
@@ -1,0 +1,77 @@
+import type { ChatMessage, NormalizedResponse, ProviderHandlerParams } from '../_shared/types.ts';
+
+const DEFAULT_AZURE_API_VERSION = '2025-01-01-preview'; // Or another suitable default
+
+export async function handleCustomAzureOpenAI(
+  apiKey: string,
+  model: string, // This might be the deployment_id or a generic model name passed from the client
+  messages: ChatMessage[],
+  temperature: number,
+  max_tokens: number,
+  stream: boolean = false,
+  providerParams?: ProviderHandlerParams
+): Promise<NormalizedResponse | ReadableStream> {
+  const endpointUrl = providerParams?.endpoint_url;
+  const deploymentId = providerParams?.deployment_id;
+
+  if (!endpointUrl || !deploymentId) {
+    throw new Error('Azure OpenAI endpoint URL or deployment ID is not configured for this API key.');
+  }
+
+  // Ensure endpointUrl ends with a slash if it doesn't already
+  const normalizedEndpointUrl = endpointUrl.endsWith('/') ? endpointUrl : `${endpointUrl}/`;
+
+  const fullUrl = `${normalizedEndpointUrl}openai/deployments/${deploymentId}/chat/completions?api-version=${DEFAULT_AZURE_API_VERSION}`;
+
+  const requestBody = {
+    messages,
+    temperature,
+    max_tokens,
+    stream,
+    // Azure OpenAI might not use the 'model' field in the body if the deployment ID in URL specifies the model.
+    // If it's needed, 'model' (which could be the deploymentId or another value) can be added here.
+    // model: model,
+  };
+
+  // Log the request body and URL for debugging (optional)
+  console.log("Custom Azure OpenAI Request URL:", fullUrl);
+  console.log("Custom Azure OpenAI Request Body:", JSON.stringify(requestBody, null, 2));
+
+  const response = await fetch(fullUrl, {
+    method: 'POST',
+    headers: {
+      'api-key': apiKey, // Azure OpenAI typically uses 'api-key' header
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    console.error("Custom Azure OpenAI API Error:", errorText);
+    throw new Error(`Custom Azure OpenAI API error: ${response.status} ${errorText}`);
+  }
+
+  if (stream) {
+    if (!response.body) {
+      throw new Error('Custom Azure OpenAI API response body is null for stream.');
+    }
+    // Assuming Azure OpenAI streaming is compatible with the standard SSE parsing in the main function.
+    return response.body;
+  }
+
+  const data = await response.json();
+  console.log("Custom Azure OpenAI Response Data:", JSON.stringify(data, null, 2));
+
+  if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+    console.error("Unexpected Custom Azure OpenAI response structure:", data);
+    throw new Error('Unexpected Custom Azure OpenAI API response structure');
+  }
+
+  return {
+    content: data.choices[0].message.content,
+    usage: data.usage,
+    model: data.model || deploymentId, // Use model from response, or fallback to deploymentId
+    provider: 'Azure OpenAI (Custom)'
+  };
+}

--- a/supabase/functions/ai-chat/providers/straico.test.ts
+++ b/supabase/functions/ai-chat/providers/straico.test.ts
@@ -1,0 +1,177 @@
+import { assertEquals, assertRejects, assertInstanceOf } from "https://deno.land/std@0.208.0/assert/mod.ts";
+import { handleStraico } from "./straico.ts";
+import type { ChatMessage, NormalizedResponse } from '../_shared/types.ts';
+
+// Store original fetch to restore it after tests
+const originalFetch = globalThis.fetch;
+
+Deno.test("handleStraico - successful non-streaming response", async () => {
+  globalThis.fetch = async (url: string | URL | Request, options?: RequestInit): Promise<Response> => {
+    assertEquals(url.toString(), "https://api.straico.com/v1/chat/completions");
+    if (options?.body) {
+      const body = JSON.parse(options.body as string);
+      assertEquals(body.model, "straico/latest");
+      assertEquals(body.stream, false);
+    }
+
+    return Promise.resolve(new Response(JSON.stringify({
+      choices: [{ message: { content: "Test response from Straico" } }],
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      model: "straico-model-v1" // Assuming API returns the specific model version
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    const response = await handleStraico("test-api-key", "straico/latest", messages, 0.7, 100, false) as NormalizedResponse;
+
+    assertEquals(response.content, "Test response from Straico");
+    assertEquals(response.provider, "Straico");
+    assertEquals(response.model, "straico-model-v1");
+    assertEquals(response.usage?.prompt_tokens, 10);
+    assertEquals(response.usage?.completion_tokens, 20);
+    assertEquals(response.usage?.total_tokens, 30);
+  } finally {
+    globalThis.fetch = originalFetch; // Restore fetch
+  }
+});
+
+Deno.test("handleStraico - API error handling", async () => {
+  globalThis.fetch = async (url: string | URL | Request, options?: RequestInit): Promise<Response> => {
+    assertEquals(url.toString(), "https://api.straico.com/v1/chat/completions");
+    return Promise.resolve(new Response(JSON.stringify({ error: { message: "Invalid API key" } }), {
+      status: 401,
+      headers: { 'Content-Type': 'application/json' }
+    }));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    await assertRejects(
+      async () => {
+        await handleStraico("invalid-key", "straico/latest", messages, 0.7, 100, false);
+      },
+      Error,
+      'Straico API error: 401 {"error":{"message":"Invalid API key"}}' // Adjust expected message based on actual error thrown
+    );
+  } finally {
+    globalThis.fetch = originalFetch; // Restore fetch
+  }
+});
+
+Deno.test("handleStraico - successful streaming response", async () => {
+  const mockStream = new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode("data: chunk1\n\n"));
+      controller.close();
+    }
+  });
+
+  globalThis.fetch = async (url: string | URL | Request, options?: RequestInit): Promise<Response> => {
+    assertEquals(url.toString(), "https://api.straico.com/v1/chat/completions");
+     if (options?.body) {
+      const body = JSON.parse(options.body as string);
+      assertEquals(body.model, "straico/latest");
+      assertEquals(body.stream, true);
+    }
+    return Promise.resolve(new Response(mockStream, {
+      status: 200,
+      headers: { 'Content-Type': 'text/event-stream' }
+    }));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    const response = await handleStraico("test-api-key", "straico/latest", messages, 0.7, 100, true);
+    assertInstanceOf(response, ReadableStream);
+  } finally {
+    globalThis.fetch = originalFetch; // Restore fetch
+  }
+});
+
+Deno.test("handleStraico - fetch throws network error", async () => {
+  globalThis.fetch = async (_url: string | URL | Request, _options?: RequestInit): Promise<Response> => {
+    return Promise.reject(new TypeError("Network request failed"));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    await assertRejects(
+      async () => {
+        await handleStraico("test-key", "straico/latest", messages, 0.7, 100, false);
+      },
+      TypeError, // Expecting the original TypeError from fetch
+      "Network request failed"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleStraico - non-JSON error response from API", async () => {
+  globalThis.fetch = async (_url: string | URL | Request, _options?: RequestInit): Promise<Response> => {
+    return Promise.resolve(new Response("Server Error 500 - Not JSON", {
+      status: 500,
+      headers: { 'Content-Type': 'text/plain' }
+    }));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    await assertRejects(
+      async () => {
+        await handleStraico("test-key", "straico/latest", messages, 0.7, 100, false);
+      },
+      Error,
+      "Straico API error: 500 Server Error 500 - Not JSON"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleStraico - stream response with null body", async () => {
+  globalThis.fetch = async (_url: string | URL | Request, _options?: RequestInit): Promise<Response> => {
+    return Promise.resolve(new Response(null, { // Null body
+      status: 200, // Status is OK, but body is null
+      headers: { 'Content-Type': 'text/event-stream' }
+    }));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    await assertRejects(
+      async () => {
+        await handleStraico("test-key", "straico/latest", messages, 0.7, 100, true); // stream: true
+      },
+      Error,
+      "Straico API response body is null for stream."
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+Deno.test("handleStraico - non-streaming unexpected response structure", async () => {
+  globalThis.fetch = async (_url: string | URL | Request, _options?: RequestInit): Promise<Response> => {
+    return Promise.resolve(new Response(JSON.stringify({
+      // Missing 'choices' array
+      some_other_data: "data",
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      model: "straico-model-v1"
+    }), { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  };
+
+  try {
+    const messages: ChatMessage[] = [{ role: "user", content: "Hello" }];
+    await assertRejects(
+      async () => {
+        await handleStraico("test-key", "straico/latest", messages, 0.7, 100, false);
+      },
+      Error,
+      "Unexpected Straico API response structure"
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/supabase/functions/ai-chat/providers/straico.ts
+++ b/supabase/functions/ai-chat/providers/straico.ts
@@ -1,0 +1,61 @@
+import type { ChatMessage, NormalizedResponse } from '../_shared/types.ts';
+
+export async function handleStraico(apiKey: string, model: string, messages: ChatMessage[], temperature: number, max_tokens: number, stream: boolean = false): Promise<NormalizedResponse | ReadableStream> {
+  const requestBody = {
+    model,
+    messages,
+    temperature,
+    max_tokens,
+    stream,
+  };
+
+  // Log the request body for debugging (optional, can be removed later)
+  console.log("Straico Request Body:", JSON.stringify(requestBody, null, 2));
+
+  const response = await fetch('https://api.straico.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(requestBody),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    // Log the error for debugging (optional, can be removed later)
+    console.error("Straico API Error:", errorText);
+    throw new Error(`Straico API error: ${response.status} ${errorText}`);
+  }
+
+  if (stream) {
+    // TODO: Implement streaming logic if Straico supports it and it's different from OpenAI's
+    // For now, assuming it's similar to OpenAI and the main function handles SSE parsing.
+    // If Straico uses a different streaming format, this will need adjustment.
+    if (!response.body) {
+      throw new Error('Straico API response body is null for stream.');
+    }
+    return response.body;
+  }
+
+  const data = await response.json();
+
+  // Log the response data for debugging (optional, can be removed later)
+  console.log("Straico Response Data:", JSON.stringify(data, null, 2));
+
+  // Normalize the response based on typical Straico response structure.
+  // This assumes Straico's response structure is similar to OpenAI:
+  // { choices: [{ message: { content: "..." } }], usage: { ... } }
+  // Adjust if Straico's actual response structure is different.
+  if (!data.choices || !data.choices[0] || !data.choices[0].message) {
+    console.error("Unexpected Straico response structure:", data);
+    throw new Error('Unexpected Straico API response structure');
+  }
+
+  return {
+    content: data.choices[0].message.content,
+    usage: data.usage, // Assuming 'usage' object is present and has the same structure
+    model: data.model || model, // Assuming 'model' is present in response, otherwise use requested model
+    provider: 'Straico'
+  };
+}

--- a/supabase/migrations/20250617192400_add_custom_azure_fields.sql
+++ b/supabase/migrations/20250617192400_add_custom_azure_fields.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.api_keys
+ADD COLUMN endpoint_url TEXT NULL,
+ADD COLUMN deployment_id TEXT NULL;


### PR DESCRIPTION
This commit introduces support for two new AI providers: Straico and Azure OpenAI (Custom).

Straico Integration:
- Added 'Straico' to the list of available API providers.
- Implemented `handleStraico` function in a new `straico.ts` Supabase edge function provider module to interact with the Straico API (https://api.straico.com/v1/chat/completions).
- Supports both streaming and non-streaming responses.
- Added default model 'straico/latest'.
- Included comprehensive unit tests for the Straico provider.

Azure OpenAI (Custom Endpoint) Integration:
- Added 'Azure OpenAI (Custom)' to the list of available API providers.
- Allows you to configure your own Azure OpenAI endpoint URL and deployment ID.
- Created a new Supabase migration to add `endpoint_url` and `deployment_id` columns to the `api_keys` table.
- Updated the API key form to conditionally show fields for Endpoint URL and Deployment ID.
- Implemented `handleCustomAzureOpenAI` in `customAzureOpenAI.ts` to interact with the user-configured Azure endpoint.
- The handler constructs the full request URL, uses the `api-key` header, and specifies an API version (defaulting to `2025-01-01-preview`).
- Supports both streaming and non-streaming responses.
- The main edge function and API key handler were updated to fetch and pass these custom parameters.
- Added placeholder 'user-defined' for model selection, as the actual model is tied to the deployment.
- Included comprehensive unit tests for the Azure OpenAI (Custom) provider.

Common changes:
- Updated `api_provider` enum in `types.ts`.
- Updated `aiProviderService.ts` for model definitions.
- Updated provider registry `_registry.ts` for new handlers.
- Modified `ProviderHandler` type to accept `providerParams`.